### PR TITLE
iterableの長さがちがっても対応、dictキー順が違っても許す

### DIFF
--- a/pyautest/adapter/basic_pyobjects.py
+++ b/pyautest/adapter/basic_pyobjects.py
@@ -28,7 +28,14 @@ class BasicPyobjectsAdapter(BaseAdapter[ObjectType]):
         if isinstance(obj1, iteratives) and isinstance(obj2, iteratives):
             return all([self.equal(o1, o2) for o1, o2 in zip(obj1, obj2)])
         if isinstance(obj1, dict) and isinstance(obj2, dict):
-            return all([self.equal(o1, o2) for o1, o2 in zip(obj1.items(), obj2.items())])
+            obj1_keys = set(obj1.keys())
+            obj2_keys = set(obj2.keys())
+            added_keys = obj1_keys - obj2_keys
+            removed_keys = obj2_keys - obj1_keys
+            if added_keys or removed_keys:
+                return False
+            # keys are the same
+            return all(self.equal(obj1[k], obj2[k]) for k in obj1_keys)
 
         if isinstance(obj1, float) and isinstance(obj2, float):
             return abs(obj1 - obj2) < self.allowable_error

--- a/pyautest/adapter/basic_pyobjects.py
+++ b/pyautest/adapter/basic_pyobjects.py
@@ -1,4 +1,5 @@
 import pickle
+from itertools import zip_longest
 from typing import Union, List
 
 from pyautest.adapter.base_adapter import BaseAdapter, T, PathType
@@ -26,7 +27,7 @@ class BasicPyobjectsAdapter(BaseAdapter[ObjectType]):
     def equal(self, obj1: ObjectType, obj2: ObjectType) -> bool:
         iteratives = (list, set, tuple)
         if isinstance(obj1, iteratives) and isinstance(obj2, iteratives):
-            return all([self.equal(o1, o2) for o1, o2 in zip(obj1, obj2)])
+            return all(self.equal(o1, o2) for o1, o2 in zip_longest(obj1, obj2))
         if isinstance(obj1, dict) and isinstance(obj2, dict):
             obj1_keys = set(obj1.keys())
             obj2_keys = set(obj2.keys())

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
 	name="pyautest",
-	version="0.0.1",
+	version="0.0.2",
 	description="golden file test utility",
 	url="https://github.com/higumachan/pyautest",
 	packages=find_packages(),

--- a/tests/adapter/test_basic_pyobjects.py
+++ b/tests/adapter/test_basic_pyobjects.py
@@ -36,6 +36,7 @@ def test_basic_allownance_error_success():
     assert not (_default_gold_file_test.file_directory / 'test_zeros' / "zeros.pkl").exists()
     test_zeros()
     assert (_default_gold_file_test.file_directory / 'test_zeros' / "zeros.pkl").exists()
+
     def test_zeros():
         a = 0.0000001
         assert golden_file_test('zeros', a)
@@ -44,13 +45,14 @@ def test_basic_allownance_error_success():
 
 def test_basic_allownance_error_success_dict():
     def test_zeros():
-        a = {"a": 0.0}
+        a = {"a": 0.0, "b": 6}
         assert golden_file_test('zeros', a)
     assert not (_default_gold_file_test.file_directory / 'test_zeros' / "zeros.pkl").exists()
     test_zeros()
     assert (_default_gold_file_test.file_directory / 'test_zeros' / "zeros.pkl").exists()
+
     def test_zeros():
-        a = {"a": 0.0000001}
+        a = {"b": 6, "a": 0.0000001}
         assert golden_file_test('zeros', a)
     test_zeros()
 
@@ -62,6 +64,7 @@ def test_basic_allownance_error_success_list():
     assert not (_default_gold_file_test.file_directory / 'test_zeros' / "zeros.pkl").exists()
     test_zeros()
     assert (_default_gold_file_test.file_directory / 'test_zeros' / "zeros.pkl").exists()
+
     def test_zeros():
         a = [0.0000001]
         assert golden_file_test('zeros', a)

--- a/tests/adapter/test_basic_pyobjects.py
+++ b/tests/adapter/test_basic_pyobjects.py
@@ -29,6 +29,22 @@ def test_basic_adapter_failed():
         test_zeros()
 
 
+def test_basic_adapter_uneven_list():
+    def test_zeros():
+        a = [0, 0, 0]
+        assert golden_file_test('zeros', a)
+
+    test_zeros()
+
+    def test_zeros():
+        a = [0, 0, 0, 1]
+        return golden_file_test('zeros', a)
+
+    expected = False
+    actual = test_zeros()
+    assert actual == expected
+
+
 def test_basic_allownance_error_success():
     def test_zeros():
         a = 0.0


### PR DESCRIPTION
下記だと、キーの順が変わったら、等しくないと判定されます：
```
all([self.equal(o1, o2) for o1, o2 in zip(obj1.items(), obj2.items())])
```

キーの順が違っても許せるように、o1, o2のキー比較とvalue比較を分けました。